### PR TITLE
ci: run CI on merge_group (Doctrine ADR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    types: [checks_requested]
   # Allow manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
Queue-readiness per Doctrine ADR-2 default-on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)